### PR TITLE
Fix build error: sort is undefined 

### DIFF
--- a/src/target/x86.cc
+++ b/src/target/x86.cc
@@ -18,6 +18,7 @@
 #include "stitch/target/x86.h"
 
 #include <iostream>
+#include <algorithm>
 
 namespace stitch {
 Function* X86Code::EditFunction(const VA address, const Section& scn) {


### PR DESCRIPTION
added include <algorithm> for build error, built using visual studio 2022